### PR TITLE
#65 - Refactor user endpoints to use 'id' instead of 'userId'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Or via tools like `curl` and `Postman`.
 ```bash
 curl -X POST -H "Content-Type: application/json" \
 -d '{"name":"Alexandre", "email":"alexandre@example.com", "age":30, "password":"Test@123"}' \
-http://localhost:8080/createUser
+http://localhost:8080/user/create
 ```
 
 * **Update user**:
@@ -69,13 +69,13 @@ http://localhost:8080/createUser
 ```bash
 curl -X PUT -H "Content-Type: application/json" \
 -d '{"name":"Alexandre Neto"}' \
-http://localhost:8080/updateUser/{userId}
+http://localhost:8080/user/create/{id}
 ```
 
 * **Delete user**:
 
 ```bash
-curl -X DELETE http://localhost:8080/deleteUser/{userId}
+curl -X DELETE http://localhost:8080/user/delete/{id}
 ```
 
 ---
@@ -133,28 +133,28 @@ causes   []struct {
 > For protected endpoints, include the token in the `Authorization` header:
 > `Bearer <your-access-token>`
 
-### **POST /createUser**
+### **POST /user/create**
 
 * Create a new user
 * Body: `UserRequest`
 * Response: `200 OK`, `400 Bad Request`, `500 Internal Server Error`
 
-### **DELETE /deleteUser/{userId}**
+### **DELETE /user/delete/{id}**
 
 * Delete user by ID
-* Path param: `userId`
+* Path param: `id`
 * Response: `200 OK`, `400`, `500`
 
-### **GET /getUserByEmail/{email}**
+### **GET /user/email/{email}**
 
 * Get user by email
 * Path param: `email`
 * Response: `200 OK`, `404 Not Found`, `400 Invalid ID`
 
-### **GET /getUserById/{userId}**
+### **GET /user/id/{id}**
 
 * Get user by ID
-* Path param: `userId`
+* Path param: `id`
 * Response: `200 OK`, `404 Not Found`, `400 Invalid ID`
 
 ### **POST /login**
@@ -163,10 +163,10 @@ causes   []struct {
 * Body: `UserLogin`
 * Response: `200 OK (returns token)`, `403 Forbidden`
 
-### **PUT /updateUser/{userId}**
+### **PUT /user/update/{id}**
 
 * Update user info by ID
-* Path param: `userId`
+* Path param: `id`
 * Body: `UserUpdateRequest`
 * Response: `200 OK`, `400`, `500`
 

--- a/src/controller/create_user.go
+++ b/src/controller/create_user.go
@@ -22,7 +22,7 @@ import (
 // @Success 200 {object} response.UserResponse
 // @Failure 400 {object} rest_err.RestErr
 // @Failure 500 {object} rest_err.RestErr
-// @Router /createUser [post]
+// @Router /user/create [post]
 func (uc *userControllerInterface) CreateUser(c *gin.Context) {
 	logger.Info("Init CreateUser controller",
 		zap.String("journey", "createUser"),
@@ -56,7 +56,7 @@ func (uc *userControllerInterface) CreateUser(c *gin.Context) {
 
 	logger.Info(
 		"CreateUser controller executed successfully",
-		zap.String("userId", domainResult.GetID()),
+		zap.String("id", domainResult.GetID()),
 		zap.String("journey", "createUser"))
 
 	c.JSON(http.StatusOK, view.ConvertDomainToResponse(

--- a/src/controller/delete_user.go
+++ b/src/controller/delete_user.go
@@ -16,25 +16,25 @@ import (
 // @Tags Users
 // @Accept json
 // @Produce json
-// @Param userId path string true "ID of the user to be deleted"
+// @Param id path string true "ID of the user to be deleted"
 // @Success 200
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Failure 400 {object} rest_err.RestErr
 // @Failure 500 {object} rest_err.RestErr
-// @Router /deleteUser/{userId} [delete]
+// @Router /user/delete/{id} [delete]
 func (uc *userControllerInterface) DeleteUser(c *gin.Context) {
 	logger.Info("Init deleteUser controller",
 		zap.String("journey", "deleteUser"),
 	)
 
-	userId := c.Param("userId")
-	if _, err := primitive.ObjectIDFromHex(userId); err != nil {
-		errRest := rest_err.NewBadRequestError("Invalid userId, must be a hex value")
+	id := c.Param("id")
+	if _, err := primitive.ObjectIDFromHex(id); err != nil {
+		errRest := rest_err.NewBadRequestError("Invalid id, must be a hex value")
 		c.JSON(errRest.Code, errRest)
 		return
 	}
 
-	err := uc.service.DeleteUser(userId)
+	err := uc.service.DeleteUser(id)
 	if err != nil {
 		logger.Error(
 			"Error trying to call deleteUser service",
@@ -46,7 +46,7 @@ func (uc *userControllerInterface) DeleteUser(c *gin.Context) {
 
 	logger.Info(
 		"deleteUser controller executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "deleteUser"))
 
 	c.Status(http.StatusOK)

--- a/src/controller/delete_user_test.go
+++ b/src/controller/delete_user_test.go
@@ -21,13 +21,13 @@ func TestUserControllerInterface_DeleteUser(t *testing.T) {
 	service := mocks.NewMockUserDomainService(ctrl)
 	controller := NewUserControllerInterface(service)
 
-	t.Run("userId_is_invalid_returns_error", func(t *testing.T) {
+	t.Run("id_is_invalid_returns_error", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		context := GetTestGinContext(recorder)
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: "teste",
 			},
 		}
@@ -45,7 +45,7 @@ func TestUserControllerInterface_DeleteUser(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}
@@ -66,7 +66,7 @@ func TestUserControllerInterface_DeleteUser(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}

--- a/src/controller/find_user.go
+++ b/src/controller/find_user.go
@@ -18,33 +18,33 @@ import (
 // @Tags Users
 // @Accept json
 // @Produce json
-// @Param userId path string true "ID of the user to be retrieved"
+// @Param id path string true "ID of the user to be retrieved"
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Success 200 {object} response.UserResponse "User information retrieved successfully"
 // @Failure 400 {object} rest_err.RestErr "Error: Invalid user ID"
 // @Failure 404 {object} rest_err.RestErr "User not found"
-// @Router /getUserById/{userId} [get]
+// @Router /user/id/{id} [get]
 func (uc *userControllerInterface) FindUserByID(c *gin.Context) {
 	logger.Info("Init findUserByID controller",
 		zap.String("journey", "findUserByID"),
 	)
 
-	userId := c.Param("userId")
+	id := c.Param("id")
 
-	if _, err := primitive.ObjectIDFromHex(userId); err != nil {
-		logger.Error("Error trying to validate userId",
+	if _, err := primitive.ObjectIDFromHex(id); err != nil {
+		logger.Error("Error trying to validate id",
 			err,
 			zap.String("journey", "findUserByID"),
 		)
 		errorMessage := rest_err.NewBadRequestError(
-			"UserID is not a valid id",
+			"id is not a valid id",
 		)
 
 		c.JSON(errorMessage.Code, errorMessage)
 		return
 	}
 
-	userDomain, err := uc.service.FindUserByIDServices(userId)
+	userDomain, err := uc.service.FindUserByIDServices(id)
 	if err != nil {
 		logger.Error("Error trying to call findUserByID services",
 			err,
@@ -73,7 +73,7 @@ func (uc *userControllerInterface) FindUserByID(c *gin.Context) {
 // @Success 200 {object} response.UserResponse "User information retrieved successfully"
 // @Failure 400 {object} rest_err.RestErr "Error: Invalid user ID"
 // @Failure 404 {object} rest_err.RestErr "User not found"
-// @Router /getUserByEmail/{userEmail} [get]
+// @Router /user/email/{userEmail} [get]
 func (uc *userControllerInterface) FindUserByEmail(c *gin.Context) {
 	logger.Info("Init findUserByEmail controller",
 		zap.String("journey", "findUserByEmail"),

--- a/src/controller/find_user_test.go
+++ b/src/controller/find_user_test.go
@@ -99,7 +99,7 @@ func TestUserControllerInterface_FindUserById(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: "teste",
 			},
 		}
@@ -117,7 +117,7 @@ func TestUserControllerInterface_FindUserById(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}
@@ -138,7 +138,7 @@ func TestUserControllerInterface_FindUserById(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}

--- a/src/controller/login_user.go
+++ b/src/controller/login_user.go
@@ -54,7 +54,7 @@ func (uc *userControllerInterface) LoginUser(c *gin.Context) {
 
 	logger.Info(
 		"loginUser controller executed successfully",
-		zap.String("userId", domainResult.GetID()),
+		zap.String("id", domainResult.GetID()),
 		zap.String("journey", "loginUser"))
 
 	c.Header("Authorization", token)

--- a/src/controller/routes/routes.go
+++ b/src/controller/routes/routes.go
@@ -13,11 +13,11 @@ func InitRoutes(
 	r *gin.RouterGroup,
 	userController controller.UserControllerInterface) {
 
-	r.GET("/getUserById/:userId", model.VerifyTokenMiddleware, userController.FindUserByID)
-	r.GET("/getUserByEmail/:userEmail", model.VerifyTokenMiddleware, userController.FindUserByEmail)
-	r.POST("/createUser", userController.CreateUser)
-	r.PUT("/updateUser/:userId", model.VerifyTokenMiddleware, userController.UpdateUser)
-	r.DELETE("/deleteUser/:userId", model.VerifyTokenMiddleware, userController.DeleteUser)
+	r.GET("/user/id/:id", model.VerifyTokenMiddleware, userController.FindUserByID)
+	r.GET("/user/email/:userEmail", model.VerifyTokenMiddleware, userController.FindUserByEmail)
+	r.POST("/user/create", userController.CreateUser)
+	r.PUT("/user/update/:id", model.VerifyTokenMiddleware, userController.UpdateUser)
+	r.DELETE("/user/delete/:id", model.VerifyTokenMiddleware, userController.DeleteUser)
 
 	r.POST("/login", userController.LoginUser)
 

--- a/src/controller/update_user.go
+++ b/src/controller/update_user.go
@@ -19,13 +19,13 @@ import (
 // @Tags Users
 // @Accept json
 // @Produce json
-// @Param userId path string true "ID of the user to be updated"
+// @Param id path string true "ID of the user to be updated"
 // @Param userRequest body request.UserUpdateRequest true "User information for update"
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Success 200
 // @Failure 400 {object} rest_err.RestErr
 // @Failure 500 {object} rest_err.RestErr
-// @Router /updateUser/{userId} [put]
+// @Router /user/update/{id} [put]
 func (uc *userControllerInterface) UpdateUser(c *gin.Context) {
 	logger.Info("Init updateUser controller",
 		zap.String("journey", "updateUser"),
@@ -41,9 +41,9 @@ func (uc *userControllerInterface) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	userId := c.Param("userId")
-	if _, err := primitive.ObjectIDFromHex(userId); err != nil {
-		errRest := rest_err.NewBadRequestError("Invalid userId, must be a hex value")
+	id := c.Param("id")
+	if _, err := primitive.ObjectIDFromHex(id); err != nil {
+		errRest := rest_err.NewBadRequestError("Invalid id, must be a hex value")
 		c.JSON(errRest.Code, errRest)
 	}
 
@@ -51,7 +51,7 @@ func (uc *userControllerInterface) UpdateUser(c *gin.Context) {
 		userRequest.Name,
 		userRequest.Age,
 	)
-	err := uc.service.UpdateUser(userId, domain)
+	err := uc.service.UpdateUser(id, domain)
 	if err != nil {
 		logger.Error(
 			"Error trying to call updateUser service",
@@ -63,7 +63,7 @@ func (uc *userControllerInterface) UpdateUser(c *gin.Context) {
 
 	logger.Info(
 		"updateUser controller executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "updateUser"))
 
 	c.Status(http.StatusOK)

--- a/src/controller/update_user_test.go
+++ b/src/controller/update_user_test.go
@@ -44,7 +44,7 @@ func TestUserControllerInterface_UpdateUser(t *testing.T) {
 		assert.EqualValues(t, http.StatusBadRequest, recorder.Code)
 	})
 
-	t.Run("validation_userId_got_error", func(t *testing.T) {
+	t.Run("validation_id_got_error", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		context := GetTestGinContext(recorder)
 
@@ -55,7 +55,7 @@ func TestUserControllerInterface_UpdateUser(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: "test",
 			},
 		}
@@ -76,7 +76,7 @@ func TestUserControllerInterface_UpdateUser(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}
@@ -109,7 +109,7 @@ func TestUserControllerInterface_UpdateUser(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}

--- a/src/model/repository/create_user_repository.go
+++ b/src/model/repository/create_user_repository.go
@@ -36,7 +36,7 @@ func (ur *userRepository) CreateUser(
 
 	logger.Info(
 		"CreateUser repository executed successfully",
-		zap.String("userId", value.ID.Hex()),
+		zap.String("id", value.ID.Hex()),
 		zap.String("journey", "createUser"))
 
 	return converter.ConvertEntityToDomain(*value), nil

--- a/src/model/repository/delete_user_repository.go
+++ b/src/model/repository/delete_user_repository.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (ur *userRepository) DeleteUser(
-	userId string,
+	id string,
 ) *rest_err.RestErr {
 	logger.Info("Init deleteUser repository",
 		zap.String("journey", "deleteUser"))
@@ -20,9 +20,9 @@ func (ur *userRepository) DeleteUser(
 	collection_name := os.Getenv(MONGODB_USER_DB)
 	collection := ur.databaseConnection.Collection(collection_name)
 
-	userIdHex, _ := primitive.ObjectIDFromHex(userId)
+	idHex, _ := primitive.ObjectIDFromHex(id)
 
-	filter := bson.D{{Key: "_id", Value: userIdHex}}
+	filter := bson.D{{Key: "_id", Value: idHex}}
 
 	_, err := collection.DeleteOne(context.Background(), filter)
 	if err != nil {
@@ -34,7 +34,7 @@ func (ur *userRepository) DeleteUser(
 
 	logger.Info(
 		"deleteUser repository executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "deleteUser"))
 
 	return nil

--- a/src/model/repository/delete_user_repository_test.go
+++ b/src/model/repository/delete_user_repository_test.go
@@ -23,7 +23,7 @@ func TestUserRepository_DeleteUser(t *testing.T) {
 	mtestDb := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 	defer mtestDb.Close()
 
-	mtestDb.Run("when_sending_a_valid_userId_return_success", func(mt *mtest.T) {
+	mtestDb.Run("when_sending_a_valid_id_return_success", func(mt *mtest.T) {
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: 1},

--- a/src/model/repository/find_user_repository.go
+++ b/src/model/repository/find_user_repository.go
@@ -54,7 +54,7 @@ func (ur *userRepository) FindUserByEmail(
 	logger.Info("FindUserByEmail repository executed successfully",
 		zap.String("journey", "findUserByEmail"),
 		zap.String("email", email),
-		zap.String("userId", userEntity.ID.Hex()))
+		zap.String("id", userEntity.ID.Hex()))
 	return converter.ConvertEntityToDomain(*userEntity), nil
 }
 
@@ -96,7 +96,7 @@ func (ur *userRepository) FindUserByID(
 
 	logger.Info("FindUserByID repository executed successfully",
 		zap.String("journey", "findUserByID"),
-		zap.String("userId", userEntity.ID.Hex()))
+		zap.String("id", userEntity.ID.Hex()))
 	return converter.ConvertEntityToDomain(*userEntity), nil
 }
 
@@ -141,6 +141,6 @@ func (ur *userRepository) FindUserByEmailAndPassword(
 	logger.Info("FindUserByEmailAndPassword repository executed successfully",
 		zap.String("journey", "findUserByEmailAndPassword"),
 		zap.String("email", email),
-		zap.String("userId", userEntity.ID.Hex()))
+		zap.String("id", userEntity.ID.Hex()))
 	return converter.ConvertEntityToDomain(*userEntity), nil
 }

--- a/src/model/repository/update_user_repository.go
+++ b/src/model/repository/update_user_repository.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (ur *userRepository) UpdateUser(
-	userId string,
+	id string,
 	userDomain model.UserDomainInterface,
 ) *rest_err.RestErr {
 	logger.Info("Init updateUser repository",
@@ -24,9 +24,9 @@ func (ur *userRepository) UpdateUser(
 	collection := ur.databaseConnection.Collection(collection_name)
 
 	value := converter.ConvertDomainToEntity(userDomain)
-	userIdHex, _ := primitive.ObjectIDFromHex(userId)
+	idHex, _ := primitive.ObjectIDFromHex(id)
 
-	filter := bson.D{{Key: "_id", Value: userIdHex}}
+	filter := bson.D{{Key: "_id", Value: idHex}}
 	update := bson.D{{Key: "$set", Value: value}}
 
 	_, err := collection.UpdateOne(context.Background(), filter, update)
@@ -39,7 +39,7 @@ func (ur *userRepository) UpdateUser(
 
 	logger.Info(
 		"updateUser repository executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "updateUser"))
 
 	return nil

--- a/src/model/repository/user_repository.go
+++ b/src/model/repository/user_repository.go
@@ -28,12 +28,12 @@ type UserRepository interface {
 	) (model.UserDomainInterface, *rest_err.RestErr)
 
 	UpdateUser(
-		userId string,
+		id string,
 		userDomain model.UserDomainInterface,
 	) *rest_err.RestErr
 
 	DeleteUser(
-		userId string,
+		id string,
 	) *rest_err.RestErr
 
 	FindUserByEmail(

--- a/src/model/service/create_user.go
+++ b/src/model/service/create_user.go
@@ -30,7 +30,7 @@ func (ud *userDomainService) CreateUserServices(
 
 	logger.Info(
 		"CreateUser service executed successfully",
-		zap.String("userId", userDomainRepository.GetID()),
+		zap.String("id", userDomainRepository.GetID()),
 		zap.String("journey", "createUser"))
 	return userDomainRepository, nil
 }

--- a/src/model/service/delete_user.go
+++ b/src/model/service/delete_user.go
@@ -7,12 +7,12 @@ import (
 )
 
 func (ud *userDomainService) DeleteUser(
-	userId string) *rest_err.RestErr {
+	id string) *rest_err.RestErr {
 
 	logger.Info("Init deleteUser model.",
 		zap.String("journey", "deleteUser"))
 
-	err := ud.userRepository.DeleteUser(userId)
+	err := ud.userRepository.DeleteUser(id)
 	if err != nil {
 		logger.Error("Error trying to call repository",
 			err,
@@ -22,7 +22,7 @@ func (ud *userDomainService) DeleteUser(
 
 	logger.Info(
 		"deleteUser service executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "deleteUser"))
 	return nil
 }

--- a/src/model/service/delete_user_test.go
+++ b/src/model/service/delete_user_test.go
@@ -17,7 +17,7 @@ func TestUserDomainService_DeleteUser(t *testing.T) {
 	repository := mocks.NewMockUserRepository(ctrl)
 	service := NewUserDomainService(repository)
 
-	t.Run("when_sending_a_valid_userId_returns_success", func(t *testing.T) {
+	t.Run("when_sending_a_valid_id_returns_success", func(t *testing.T) {
 		id := primitive.NewObjectID().Hex()
 
 		repository.EXPECT().DeleteUser(id).Return(nil)
@@ -27,7 +27,7 @@ func TestUserDomainService_DeleteUser(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("when_sending_a_invalid_userId_returns_error", func(t *testing.T) {
+	t.Run("when_sending_a_invalid_id_returns_error", func(t *testing.T) {
 		id := primitive.NewObjectID().Hex()
 
 		repository.EXPECT().DeleteUser(id).Return(

--- a/src/model/service/login_user.go
+++ b/src/model/service/login_user.go
@@ -31,7 +31,7 @@ func (ud *userDomainService) LoginUserServices(
 
 	logger.Info(
 		"loginUser service executed successfully",
-		zap.String("userId", user.GetID()),
+		zap.String("id", user.GetID()),
 		zap.String("journey", "loginUser"))
 	return user, token, nil
 }

--- a/src/model/service/update_user.go
+++ b/src/model/service/update_user.go
@@ -8,13 +8,13 @@ import (
 )
 
 func (ud *userDomainService) UpdateUser(
-	userId string,
+	id string,
 	userDomain model.UserDomainInterface,
 ) *rest_err.RestErr {
 	logger.Info("Init updateUser model.",
 		zap.String("journey", "updateUser"))
 
-	err := ud.userRepository.UpdateUser(userId, userDomain)
+	err := ud.userRepository.UpdateUser(id, userDomain)
 	if err != nil {
 		logger.Error("Error trying to call repository",
 			err,
@@ -24,7 +24,7 @@ func (ud *userDomainService) UpdateUser(
 
 	logger.Info(
 		"updateUser service executed successfully",
-		zap.String("userId", userId),
+		zap.String("id", id),
 		zap.String("journey", "updateUser"))
 	return nil
 }

--- a/src/model/service/update_user_test.go
+++ b/src/model/service/update_user_test.go
@@ -18,7 +18,7 @@ func TestUserDomainService_UpdateUser(t *testing.T) {
 	repository := mocks.NewMockUserRepository(ctrl)
 	service := NewUserDomainService(repository)
 
-	t.Run("when_sending_a_valid_user_and_userId_returns_success", func(t *testing.T) {
+	t.Run("when_sending_a_valid_user_and_id_returns_success", func(t *testing.T) {
 		id := primitive.NewObjectID().Hex()
 
 		userDomain := model.NewUserDomain("test@test.com", "test", "test", 50)
@@ -31,7 +31,7 @@ func TestUserDomainService_UpdateUser(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("when_sending_a_invalid_user_and_userId_returns_error", func(t *testing.T) {
+	t.Run("when_sending_a_invalid_user_and_id_returns_error", func(t *testing.T) {
 		id := primitive.NewObjectID().Hex()
 
 		userDomain := model.NewUserDomain("test@test.com", "test", "test", 50)

--- a/src/tests/deleteuser_test.go
+++ b/src/tests/deleteuser_test.go
@@ -2,14 +2,15 @@ package tests
 
 import (
 	"context"
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestDeleteUser(t *testing.T) {
@@ -27,7 +28,7 @@ func TestDeleteUser(t *testing.T) {
 
 	param := []gin.Param{
 		{
-			Key:   "userId",
+			Key:   "id",
 			Value: id.Hex(),
 		},
 	}

--- a/src/tests/findUser_test.go
+++ b/src/tests/findUser_test.go
@@ -101,7 +101,7 @@ func TestFindUserById(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id,
 			},
 		}
@@ -127,7 +127,7 @@ func TestFindUserById(t *testing.T) {
 
 		param := []gin.Param{
 			{
-				Key:   "userId",
+				Key:   "id",
 				Value: id.Hex(),
 			},
 		}

--- a/src/tests/mocks/user_repository_mock.go
+++ b/src/tests/mocks/user_repository_mock.go
@@ -51,17 +51,17 @@ func (mr *MockUserRepositoryMockRecorder) CreateUser(userDomain interface{}) *go
 }
 
 // DeleteUser mocks base method.
-func (m *MockUserRepository) DeleteUser(userId string) *rest_err.RestErr {
+func (m *MockUserRepository) DeleteUser(id string) *rest_err.RestErr {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUser", userId)
+	ret := m.ctrl.Call(m, "DeleteUser", id)
 	ret0, _ := ret[0].(*rest_err.RestErr)
 	return ret0
 }
 
 // DeleteUser indicates an expected call of DeleteUser.
-func (mr *MockUserRepositoryMockRecorder) DeleteUser(userId interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) DeleteUser(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockUserRepository)(nil).DeleteUser), userId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockUserRepository)(nil).DeleteUser), id)
 }
 
 // FindUserByEmail mocks base method.
@@ -110,15 +110,15 @@ func (mr *MockUserRepositoryMockRecorder) FindUserByID(id interface{}) *gomock.C
 }
 
 // UpdateUser mocks base method.
-func (m *MockUserRepository) UpdateUser(userId string, userDomain model.UserDomainInterface) *rest_err.RestErr {
+func (m *MockUserRepository) UpdateUser(id string, userDomain model.UserDomainInterface) *rest_err.RestErr {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUser", userId, userDomain)
+	ret := m.ctrl.Call(m, "UpdateUser", id, userDomain)
 	ret0, _ := ret[0].(*rest_err.RestErr)
 	return ret0
 }
 
 // UpdateUser indicates an expected call of UpdateUser.
-func (mr *MockUserRepositoryMockRecorder) UpdateUser(userId, userDomain interface{}) *gomock.Call {
+func (mr *MockUserRepositoryMockRecorder) UpdateUser(id, userDomain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), userId, userDomain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockUserRepository)(nil).UpdateUser), id, userDomain)
 }

--- a/src/tests/updateUser_test.go
+++ b/src/tests/updateUser_test.go
@@ -38,7 +38,7 @@ func TestUpdateUser(t *testing.T) {
 
 	param := []gin.Param{
 		{
-			Key:   "userId",
+			Key:   "id",
 			Value: id.Hex(),
 		},
 	}


### PR DESCRIPTION
Updated all controller, service, repository, test, and route files to use 'id' as the path parameter instead of 'userId' for user-related endpoints. Adjusted OpenAPI documentation, log messages, and test cases accordingly. This change standardizes the API and improves consistency across the codebase.