### PR TITLE
#69 -Update Swagger paths and enhance schema descriptions

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,56 +1,18 @@
 {
+    "schemes": [
+        "http"
+    ],
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "API for crud operations on users",
+        "title": "CRUD Golang",
+        "contact": {},
+        "version": "1.0"
     },
+    "host": "localhost:8080",
+    "basePath": "/",
     "paths": {
-        "/login": {
-            "post": {
-                "description": "Allows a user to log in and receive an authentication token.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "User Login",
-                "parameters": [
-                    {
-                        "description": "User login credentials",
-                        "name": "userLogin",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.UserLogin"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Login successful, authentication token provided",
-                        "schema": {
-                            "$ref": "#/definitions/response.UserResponse"
-                        },
-                        "headers": {
-                            "Authorization": {
-                                "type": "string",
-                                "description": "Authentication token"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Error: Invalid login credentials",
-                        "schema": {
-                            "$ref": "#/definitions/rest_err.RestErr"
-                        }
-                    }
-                }
-            }
-        },
-        "/user/create": {
+        "/createUser": {
             "post": {
                 "description": "Create a new user with the provided user information",
                 "consumes": [
@@ -96,7 +58,7 @@
                 }
             }
         },
-        "/user/delete/{id}": {
+        "/deleteUser/{userId}": {
             "delete": {
                 "description": "Deletes a user based on the ID provided as a parameter.",
                 "consumes": [
@@ -113,7 +75,7 @@
                     {
                         "type": "string",
                         "description": "ID of the user to be deleted",
-                        "name": "id",
+                        "name": "userId",
                         "in": "path",
                         "required": true
                     },
@@ -145,7 +107,7 @@
                 }
             }
         },
-        "/user/email/{userEmail}": {
+        "/getUserByEmail/{userEmail}": {
             "get": {
                 "description": "Retrieves user details based on the email provided as a parameter.",
                 "consumes": [
@@ -197,7 +159,7 @@
                 }
             }
         },
-        "/user/id/{id}": {
+        "/getUserById/{userId}": {
             "get": {
                 "description": "Retrieves user details based on the user ID provided as a parameter.",
                 "consumes": [
@@ -214,7 +176,7 @@
                     {
                         "type": "string",
                         "description": "ID of the user to be retrieved",
-                        "name": "id",
+                        "name": "userId",
                         "in": "path",
                         "required": true
                     },
@@ -249,7 +211,53 @@
                 }
             }
         },
-        "/user/update/{id}": {
+        "/login": {
+            "post": {
+                "description": "Allows a user to log in and receive an authentication token.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "User Login",
+                "parameters": [
+                    {
+                        "description": "User login credentials",
+                        "name": "userLogin",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.UserLogin"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Login successful, authentication token provided",
+                        "schema": {
+                            "$ref": "#/definitions/response.UserResponse"
+                        },
+                        "headers": {
+                            "Authorization": {
+                                "type": "string",
+                                "description": "Authentication token"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Error: Invalid login credentials",
+                        "schema": {
+                            "$ref": "#/definitions/rest_err.RestErr"
+                        }
+                    }
+                }
+            }
+        },
+        "/updateUser/{userId}": {
             "put": {
                 "description": "Updates user details based on the ID provided as a parameter.",
                 "consumes": [
@@ -266,7 +274,7 @@
                     {
                         "type": "string",
                         "description": "ID of the user to be updated",
-                        "name": "id",
+                        "name": "userId",
                         "in": "path",
                         "required": true
                     },
@@ -310,6 +318,7 @@
     },
     "definitions": {
         "request.UserLogin": {
+            "description": "Structure containing the necessary fields for user login.",
             "type": "object",
             "required": [
                 "email",
@@ -317,10 +326,12 @@
             ],
             "properties": {
                 "email": {
+                    "description": "User's email (required and must be a valid email address).",
                     "type": "string",
                     "example": "test@test.com"
                 },
                 "password": {
+                    "description": "User's password (required, minimum of 6 characters, and must contain at least one of the characters: !@#$%*).",
                     "type": "string",
                     "minLength": 6,
                     "example": "password#@#@!2121"
@@ -328,6 +339,7 @@
             }
         },
         "request.UserRequest": {
+            "description": "Structure containing the required fields for creating a new user.",
             "type": "object",
             "required": [
                 "age",
@@ -337,22 +349,26 @@
             ],
             "properties": {
                 "age": {
+                    "description": "User's age (required, must be between 1 and 140).\n@json\n@jsonTag age\n@jsonExample 30",
                     "type": "integer",
                     "maximum": 140,
                     "minimum": 1,
                     "example": 30
                 },
                 "email": {
+                    "description": "User's email (required and must be a valid email address).\nExample: user@example.com\n@json\n@jsonTag email\n@jsonExample user@example.com\n@binding required,email",
                     "type": "string",
                     "example": "test@test.com"
                 },
                 "name": {
+                    "description": "User's name (required, minimum of 4 characters, maximum of 100 characters).\nExample: John Doe\n@json\n@jsonTag name\n@jsonExample John Doe\n@binding required,min=4,max=100",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 4,
                     "example": "John Doe"
                 },
                 "password": {
+                    "description": "User's password (required, minimum of 6 characters, and must contain at least one of the characters: !@#$%*).\n@json\n@jsonTag password\n@jsonExample P@ssw0rd!\n@binding required,min=6,containsany=!@#$%*",
                     "type": "string",
                     "minLength": 6,
                     "example": "password#@#@!2121"
@@ -367,12 +383,14 @@
             ],
             "properties": {
                 "age": {
+                    "description": "User's age (required, must be between 1 and 140).\n@json\n@jsonTag age\n@jsonExample 30\n@binding required,min=1,max=140",
                     "type": "integer",
                     "maximum": 140,
                     "minimum": 1,
                     "example": 30
                 },
                 "name": {
+                    "description": "User's name (required, minimum of 4 characters, maximum of 100 characters).\nExample: John Doe\n@json\n@jsonTag name\n@jsonExample John Doe\n@binding required,min=4,max=100",
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 4,
@@ -402,36 +420,44 @@
             }
         },
         "rest_err.Causes": {
+            "description": "Structure representing the causes of an error.",
             "type": "object",
             "properties": {
                 "field": {
+                    "description": "Field associated with the error cause.\n@json\n@jsonTag field",
                     "type": "string",
                     "example": "name"
                 },
                 "message": {
+                    "description": "Error message describing the cause.\n@json\n@jsonTag message",
                     "type": "string",
                     "example": "name is required"
                 }
             }
         },
         "rest_err.RestErr": {
+            "description": "Structure for describing why the error occurred",
             "type": "object",
             "properties": {
                 "causes": {
+                    "description": "Error causes.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/rest_err.Causes"
                     }
                 },
                 "code": {
+                    "description": "Error code.",
                     "type": "integer",
                     "example": 500
                 },
                 "error": {
+                    "description": "Error description.",
                     "type": "string",
                     "example": "internal_server_error"
                 },
                 "message": {
+                    "description": "Error message.",
                     "type": "string",
                     "example": "error trying to process request"
                 }


### PR DESCRIPTION
Renamed API endpoints for consistency (e.g., /user/create to /createUser, /user/delete/{id} to /deleteUser/{userId}), added missing scheme, host, and basePath fields, and improved schema definitions with detailed descriptions for better documentation clarity.